### PR TITLE
Fix creation of the filename when opening a root directory path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@process-engine/solutionexplorer.service",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Service for the SolutionExplorer",
   "main": "dist/amd/index.js",
   "typings": "dist/index.d.ts",

--- a/src/SolutionExplorerService.ts
+++ b/src/SolutionExplorerService.ts
@@ -18,7 +18,7 @@ export class SolutionExplorerService implements ISolutionExplorerService {
     //  TODO: Replace this by a proper RegEx
     const slicedPathspec: string = ((): string => {
       const pathIsRootOnly: boolean = pathspec.length === 1;
-      const pathDoesNotEndsWithSlash: boolean = pathspec.endsWith('/');
+      const pathDoesNotEndsWithSlash: boolean = !pathspec.endsWith('/');
       if (pathIsRootOnly || pathDoesNotEndsWithSlash) {
         return pathspec;
       } else {

--- a/src/SolutionExplorerService.ts
+++ b/src/SolutionExplorerService.ts
@@ -20,21 +20,17 @@ export class SolutionExplorerService implements ISolutionExplorerService {
      * TODO: This needs to be refactored and moved to the
      * different repositories.
      */
-    const slicedPathspec: string = ((): string => {
-      const pathIsRootOnly: boolean = pathspec.length === 1;
-      const pathDoesNotEndsWithSlash: boolean = !pathspec.endsWith('/');
-      if (pathIsRootOnly || pathDoesNotEndsWithSlash) {
-        return pathspec;
-      } else {
-        return pathspec.slice(0, -1);
-      }
-    })();
+    const pathIsNotRootOnly: boolean = pathspec !== '/';
+    const pathEndsWithSlash: boolean = pathspec.endsWith('/');
+    const trailingSlashShouldBeRemoved: boolean = pathIsNotRootOnly && pathEndsWithSlash;
+
+    this._pathspec = (trailingSlashShouldBeRemoved)
+                                        ? pathspec.slice(0, -1)
+                                        : pathspec;
 
     //  }}} Cleanup name if '/' at the end //<
 
-    await this._repository.openPath(slicedPathspec, identity);
-
-    this._pathspec = slicedPathspec;
+    await this._repository.openPath(this._pathspec, identity);
   }
 
   public async loadSolution(): Promise<ISolution> {

--- a/src/SolutionExplorerService.ts
+++ b/src/SolutionExplorerService.ts
@@ -15,8 +15,11 @@ export class SolutionExplorerService implements ISolutionExplorerService {
 
   public async openSolution(pathspec: string, identity: IIdentity): Promise<void> {
     //  Cleanup name if '/' at the end {{{ //
-    //  TODO: Replace this by a proper RegEx
 
+    /**
+     * TODO: This needs to be refactored and moved to the
+     * different repositories.
+     */
     const slicedPathspec: string = ((): string => {
       const pathIsRootOnly: boolean = pathspec.length === 1;
       const pathDoesNotEndsWithSlash: boolean = !pathspec.endsWith('/');

--- a/src/SolutionExplorerService.ts
+++ b/src/SolutionExplorerService.ts
@@ -25,7 +25,7 @@ export class SolutionExplorerService implements ISolutionExplorerService {
         return pathspec.slice(0, -1);
       }
     })();
-
+    console.log(slicedPathspec);
     //  }}} Cleanup name if '/' at the end //<
 
     await this._repository.openPath(slicedPathspec, identity);

--- a/src/SolutionExplorerService.ts
+++ b/src/SolutionExplorerService.ts
@@ -16,7 +16,16 @@ export class SolutionExplorerService implements ISolutionExplorerService {
   public async openSolution(pathspec: string, identity: IIdentity): Promise<void> {
     //  Cleanup name if '/' at the end {{{ //
     //  TODO: Replace this by a proper RegEx
-    const slicedPathspec: string = pathspec.slice(-1)[0] === '/' ? pathspec.slice(0, -1) : pathspec;
+    const slicedPathspec: string = ((): string => {
+      const pathIsRootOnly: boolean = pathspec.length === 1;
+      const pathDoesNotEndsWithSlash: boolean = pathspec.endsWith('/');
+      if (pathIsRootOnly || pathDoesNotEndsWithSlash) {
+        return pathspec;
+      } else {
+        return pathspec.slice(0, -1);
+      }
+    })();
+
     //  }}} Cleanup name if '/' at the end //<
 
     await this._repository.openPath(slicedPathspec, identity);

--- a/src/SolutionExplorerService.ts
+++ b/src/SolutionExplorerService.ts
@@ -24,9 +24,9 @@ export class SolutionExplorerService implements ISolutionExplorerService {
     const pathEndsWithSlash: boolean = pathspec.endsWith('/');
     const trailingSlashShouldBeRemoved: boolean = pathIsNotRootOnly && pathEndsWithSlash;
 
-    this._pathspec = (trailingSlashShouldBeRemoved)
-                                        ? pathspec.slice(0, -1)
-                                        : pathspec;
+    this._pathspec = trailingSlashShouldBeRemoved
+      ? pathspec.slice(0, -1)
+      : pathspec;
 
     //  }}} Cleanup name if '/' at the end //<
 

--- a/src/SolutionExplorerService.ts
+++ b/src/SolutionExplorerService.ts
@@ -16,6 +16,7 @@ export class SolutionExplorerService implements ISolutionExplorerService {
   public async openSolution(pathspec: string, identity: IIdentity): Promise<void> {
     //  Cleanup name if '/' at the end {{{ //
     //  TODO: Replace this by a proper RegEx
+
     const slicedPathspec: string = ((): string => {
       const pathIsRootOnly: boolean = pathspec.length === 1;
       const pathDoesNotEndsWithSlash: boolean = !pathspec.endsWith('/');
@@ -25,7 +26,7 @@ export class SolutionExplorerService implements ISolutionExplorerService {
         return pathspec.slice(0, -1);
       }
     })();
-    console.log(slicedPathspec);
+
     //  }}} Cleanup name if '/' at the end //<
 
     await this._repository.openPath(slicedPathspec, identity);


### PR DESCRIPTION
Currently, when opening a root directory on macOS or linux, the leading slash will be removed, which results in an empty path that is passed to the repository. 

Related Issue: https://github.com/process-engine/bpmn-studio/issues/1025